### PR TITLE
Add v67 JS/CSS Fix

### DIFF
--- a/Fastmate.xcodeproj/project.pbxproj
+++ b/Fastmate.xcodeproj/project.pbxproj
@@ -122,7 +122,7 @@
 		5D39BECE2122383700693D7E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1110;
 				TargetAttributes = {
 					5D39BED52122383800693D7E = {
 						CreatedOnToolsVersion = 9.4.1;
@@ -309,8 +309,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Fastmate/Fastmate.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 5RNJHF933P;
 				INFOPLIST_FILE = Fastmate/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -328,8 +330,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Fastmate/Fastmate.entitlements;
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 5RNJHF933P;
 				INFOPLIST_FILE = Fastmate/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Fastmate/Fastmate.js
+++ b/Fastmate/Fastmate.js
@@ -52,6 +52,10 @@ var Fastmate = {
         var handler = Fastmate.notificationClickHandlers[id]();
         if (handler) handler();
     },
+    
+    adjustV67Width: function() {
+        document.getElementById("v67").style.maxWidth = "100%";
+    },
 };
 
 /**

--- a/Fastmate/Info.plist
+++ b/Fastmate/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Fastmate/WebViewController.m
+++ b/Fastmate/WebViewController.m
@@ -87,6 +87,7 @@ static NSString * const ShouldUseFastmailBetaUserDefaultsKey = @"shouldUseFastma
 
 - (void)webViewDidChangeURL:(NSURL *)newURL {
     [self queryToolbarColor];
+    [self adjustV67Width];
 }
 
 - (void)composeNewEmail {
@@ -219,6 +220,10 @@ static NSString * const ShouldUseFastmailBetaUserDefaultsKey = @"shouldUseFastma
     [alert beginSheetModalForWindow:self.view.window completionHandler:^(NSModalResponse returnCode) {
         completionHandler(returnCode == NSAlertFirstButtonReturn ? textField.stringValue : defaultText);
     }];
+}
+
+- (void)adjustV67Width {
+    [self.webView evaluateJavaScript:@"Fastmate.adjustV67Width()" completionHandler:nil];
 }
 
 @end


### PR DESCRIPTION
Add a JS/CSS fix that adjust the v67 DOM element to the max-width of the window. This allow you to properly see the email content within the boxes (reference of the issue: https://ibb.co/1rLmBqW ). Compiled on macOS Catalina 10.15.1 Beta 2 Developer. "About Fastmate" Font also change to white now, respecting Dark Mode.