### PR TITLE
Enabled delete and up/down arrow keys

### DIFF
--- a/Fastmate.xcodeproj/project.pbxproj
+++ b/Fastmate.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2E8C7D62275289C00015E582 /* FastmateApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E8C7D61275289C00015E582 /* FastmateApplication.m */; };
 		5D0F8E95240B910A00287BD1 /* PrintManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D0F8E94240B910A00287BD1 /* PrintManager.m */; };
 		5D14A8EB22C425B400A5ACE9 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 5D14A8EA22C425B400A5ACE9 /* Credits.rtf */; };
 		5D18D5022685E2EC002999F0 /* PDFKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D18D5012685E2EC002999F0 /* PDFKit.framework */; };
@@ -25,6 +26,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2E8C7D60275289C00015E582 /* FastmateApplication.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FastmateApplication.h; sourceTree = "<group>"; };
+		2E8C7D61275289C00015E582 /* FastmateApplication.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FastmateApplication.m; sourceTree = "<group>"; };
 		5D0F8E93240B910A00287BD1 /* PrintManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrintManager.h; sourceTree = "<group>"; };
 		5D0F8E94240B910A00287BD1 /* PrintManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PrintManager.m; sourceTree = "<group>"; };
 		5D14A8EA22C425B400A5ACE9 /* Credits.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
@@ -97,6 +100,8 @@
 			children = (
 				5D39BED92122383800693D7E /* AppDelegate.h */,
 				5D39BEDA2122383800693D7E /* AppDelegate.m */,
+				2E8C7D60275289C00015E582 /* FastmateApplication.h */,
+				2E8C7D61275289C00015E582 /* FastmateApplication.m */,
 				5D6EF779212E018700C84B4A /* MainWindowController.h */,
 				5D6EF77A212E018700C84B4A /* MainWindowController.m */,
 				5D6E3B352122FF9E00ED16C9 /* WebViewController.h */,
@@ -208,6 +213,7 @@
 				5DCFE8792258CEC5006B1A21 /* SettingsViewController.m in Sources */,
 				5D6E3B372122FF9E00ED16C9 /* WebViewController.m in Sources */,
 				5D0F8E95240B910A00287BD1 /* PrintManager.m in Sources */,
+				2E8C7D62275289C00015E582 /* FastmateApplication.m in Sources */,
 				5D39BEDB2122383800693D7E /* AppDelegate.m in Sources */,
 				5DC2AF2D225933BE004C94E5 /* VersionChecker.m in Sources */,
 			);

--- a/Fastmate/AppDelegate.h
+++ b/Fastmate/AppDelegate.h
@@ -5,5 +5,7 @@
 
 @property (nonatomic, strong) WebViewController *mainWebViewController;
 
+/// returns YES if the delegate handled the key, NO if it needs to be forwarded on
+- (BOOL)handleKey:(NSEvent *)event;
 @end
 

--- a/Fastmate/AppDelegate.m
+++ b/Fastmate/AppDelegate.m
@@ -1,13 +1,13 @@
 @import Carbon.HIToolbox;
 #import "AppDelegate.h"
-#import "UnreadCountObserver.h"
-#import "NotificationCenter.h"
-#import "WebViewController.h"
 #import "KVOBlockObserver.h"
+#import "NotificationCenter.h"
+#import "PrintManager.h"
+#import "UnreadCountObserver.h"
 #import "UserDefaultsKeys.h"
 #import "UserDefaultsKeys.h"
 #import "VersionChecker.h"
-#import "PrintManager.h"
+#import "WebViewController.h"
 
 @interface AppDelegate () <VersionCheckerDelegate, NotificationCenterDelegate>
 

--- a/Fastmate/AppDelegate.m
+++ b/Fastmate/AppDelegate.m
@@ -5,6 +5,7 @@
 #import "WebViewController.h"
 #import "KVOBlockObserver.h"
 #import "UserDefaultsKeys.h"
+#import "UserDefaultsKeys.h"
 #import "VersionChecker.h"
 #import "PrintManager.h"
 
@@ -57,6 +58,7 @@
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification {
     [NSUserDefaults.standardUserDefaults registerDefaults:@{
+        ArrowNavigatesMessageListKey: @NO,
         AutomaticUpdateChecksKey: @YES,
         ShouldShowUnreadMailIndicatorKey: @YES,
         ShouldShowUnreadMailInDockKey: @YES,
@@ -194,10 +196,18 @@
 - (BOOL)handleKey:(NSEvent *)event {
     switch (event.keyCode) {
         case kVK_UpArrow:
-            return [self.mainWebViewController nextMessage];
+        if ([NSUserDefaults.standardUserDefaults boolForKey:ArrowNavigatesMessageListKey]) {
+          return [self.mainWebViewController nextMessage];
+        } else {
+            return NO;
+        }
             
         case kVK_DownArrow:
-            return [self.mainWebViewController previousMessage];
+        if ([NSUserDefaults.standardUserDefaults boolForKey:ArrowNavigatesMessageListKey]) {
+          return [self.mainWebViewController previousMessage];
+        } else {
+            return NO;
+        }
 
         case kVK_Delete:
             return [self.mainWebViewController deleteMessage];

--- a/Fastmate/AppDelegate.m
+++ b/Fastmate/AppDelegate.m
@@ -1,3 +1,4 @@
+@import Carbon.HIToolbox;
 #import "AppDelegate.h"
 #import "UnreadCountObserver.h"
 #import "NotificationCenter.h"
@@ -187,6 +188,23 @@
 
 - (void)notificationCenter:(NotificationCenter *)center notificationClickedWithIdentifier:(NSString *)identifier {
     [self.mainWebViewController handleNotificationClickWithIdentifier:identifier];
+}
+
+#pragma mark - Raw key handler
+- (BOOL)handleKey:(NSEvent *)event {
+    switch (event.keyCode) {
+        case kVK_UpArrow:
+            return [self.mainWebViewController nextMessage];
+            
+        case kVK_DownArrow:
+            return [self.mainWebViewController previousMessage];
+
+        case kVK_Delete:
+            return [self.mainWebViewController deleteMessage];
+            
+        default:
+            return NO;
+    }
 }
 
 @end

--- a/Fastmate/Base.lproj/Main.storyboard
+++ b/Fastmate/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -420,14 +420,14 @@
                                 <tabViewItems>
                                     <tabViewItem label="General" identifier="" id="hnf-kG-bEx">
                                         <view key="view" id="73O-7K-AJB">
-                                            <rect key="frame" x="10" y="33" width="489" height="183"/>
+                                            <rect key="frame" x="10" y="33" width="489" height="196"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1mu-qt-Cqa">
-                                                    <rect key="frame" x="20" y="20" width="449" height="153"/>
+                                                    <rect key="frame" x="20" y="20" width="449" height="160"/>
                                                     <subviews>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wHh-Lm-p2V">
-                                                            <rect key="frame" x="-2" y="137" width="114" height="18"/>
+                                                            <rect key="frame" x="-2" y="143" width="118" height="18"/>
                                                             <buttonCell key="cell" type="check" title="Status bar icon" bezelStyle="regularSquare" imagePosition="left" inset="2" id="8gw-B7-OXa">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -437,7 +437,7 @@
                                                             </connections>
                                                         </button>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JZP-eC-7zx">
-                                                            <rect key="frame" x="-2" y="115" width="145" height="18"/>
+                                                            <rect key="frame" x="-2" y="119" width="149" height="18"/>
                                                             <buttonCell key="cell" type="check" title="Transparent title bar" bezelStyle="regularSquare" imagePosition="left" inset="2" id="bJx-Lb-CNa">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -447,10 +447,10 @@
                                                             </connections>
                                                         </button>
                                                         <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Prd-t9-ja9">
-                                                            <rect key="frame" x="0.0" y="77" width="417" height="32"/>
+                                                            <rect key="frame" x="0.0" y="78" width="417" height="34"/>
                                                             <subviews>
                                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="am0-9G-NfW">
-                                                                    <rect key="frame" x="-2" y="16" width="157" height="18"/>
+                                                                    <rect key="frame" x="-2" y="17" width="161" height="18"/>
                                                                     <buttonCell key="cell" type="check" title="Use beta.fastmail.com" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="MDM-GW-3pA">
                                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                         <font key="font" metaFont="system"/>
@@ -481,13 +481,13 @@
                                                             </customSpacing>
                                                         </stackView>
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Oz3-ky-hOk" userLabel="Spacer">
-                                                            <rect key="frame" x="0.0" y="64" width="163" height="5"/>
+                                                            <rect key="frame" x="0.0" y="65" width="163" height="5"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="5" id="Rxd-XH-5nB"/>
                                                             </constraints>
                                                         </customView>
                                                         <button horizontalHuggingPriority="1000" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="A5m-hB-YIt">
-                                                            <rect key="frame" x="162" y="28" width="125" height="32"/>
+                                                            <rect key="frame" x="165" y="30" width="119" height="32"/>
                                                             <buttonCell key="cell" type="push" title="User scripts..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="D1o-Zq-KvC">
                                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -497,13 +497,13 @@
                                                             </connections>
                                                         </button>
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Fa1-6f-X9j" userLabel="Spacer">
-                                                            <rect key="frame" x="0.0" y="22" width="163" height="5"/>
+                                                            <rect key="frame" x="0.0" y="24" width="163" height="5"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="5" id="CcB-U8-G2y"/>
                                                             </constraints>
                                                         </customView>
                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l3Z-PT-73n">
-                                                            <rect key="frame" x="-2" y="-2" width="297" height="18"/>
+                                                            <rect key="frame" x="-2" y="-1" width="301" height="18"/>
                                                             <buttonCell key="cell" type="check" title="Check for updates automatically once a week" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Pmr-DN-ABx">
                                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                 <font key="font" metaFont="system"/>
@@ -539,18 +539,18 @@
                                             <constraints>
                                                 <constraint firstAttribute="trailing" secondItem="1mu-qt-Cqa" secondAttribute="trailing" constant="20" id="Xh9-Sj-6xJ"/>
                                                 <constraint firstItem="1mu-qt-Cqa" firstAttribute="leading" secondItem="73O-7K-AJB" secondAttribute="leading" constant="20" id="bKx-4t-Lrp"/>
-                                                <constraint firstItem="1mu-qt-Cqa" firstAttribute="top" secondItem="73O-7K-AJB" secondAttribute="top" constant="10" id="d1x-9G-Lcd"/>
+                                                <constraint firstItem="1mu-qt-Cqa" firstAttribute="top" secondItem="73O-7K-AJB" secondAttribute="top" constant="16" id="d1x-9G-Lcd"/>
                                                 <constraint firstAttribute="bottom" secondItem="1mu-qt-Cqa" secondAttribute="bottom" constant="20" id="z2o-O7-bPr"/>
                                             </constraints>
                                         </view>
                                     </tabViewItem>
                                     <tabViewItem label="Unread mail" identifier="" id="uyZ-0O-rpQ">
                                         <view key="view" id="Khe-zp-uTT">
-                                            <rect key="frame" x="10" y="33" width="489" height="162"/>
+                                            <rect key="frame" x="10" y="33" width="489" height="183"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KAu-cU-cJ0">
-                                                    <rect key="frame" x="15" y="143" width="186" height="18"/>
+                                                    <rect key="frame" x="18" y="150" width="190" height="18"/>
                                                     <buttonCell key="cell" type="check" title="Show unread mail indicator" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Yfp-Sh-EwB">
                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                         <font key="font" metaFont="system"/>
@@ -560,7 +560,7 @@
                                                     </connections>
                                                 </button>
                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1Jb-9h-IKg">
-                                                    <rect key="frame" x="33" y="121" width="98" height="18"/>
+                                                    <rect key="frame" x="36" y="126" width="102" height="18"/>
                                                     <buttonCell key="cell" type="check" title="In status bar" bezelStyle="regularSquare" imagePosition="left" enabled="NO" state="on" inset="2" id="Gkr-VU-KSs">
                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                         <font key="font" metaFont="system"/>
@@ -579,13 +579,13 @@
                                                     </connections>
                                                 </button>
                                                 <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="MrS-D3-Aff">
-                                                    <rect key="frame" x="29" y="4" width="446" height="116"/>
+                                                    <rect key="frame" x="32" y="4" width="443" height="120"/>
                                                     <view key="contentView" id="B19-hn-7uA">
-                                                        <rect key="frame" x="3" y="3" width="440" height="110"/>
+                                                        <rect key="frame" x="3" y="3" width="437" height="114"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YCp-1G-ZNC">
-                                                                <rect key="frame" x="186" y="5" width="249" height="21"/>
+                                                                <rect key="frame" x="191" y="5" width="241" height="21"/>
                                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" placeholderString="Inbox, Work" drawsBackground="YES" id="IU3-z2-8M1">
                                                                     <font key="font" metaFont="system"/>
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -627,7 +627,7 @@
                                                                 </connections>
                                                             </textField>
                                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uEB-WR-Zf2">
-                                                                <rect key="frame" x="1" y="92" width="68" height="18"/>
+                                                                <rect key="frame" x="1" y="95" width="72" height="18"/>
                                                                 <buttonCell key="cell" type="check" title="In Dock" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="vB6-iF-Oij">
                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                     <font key="font" metaFont="system"/>
@@ -638,7 +638,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hCF-3X-QnZ">
-                                                                <rect key="frame" x="19" y="70" width="94" height="18"/>
+                                                                <rect key="frame" x="19" y="71" width="98" height="18"/>
                                                                 <buttonCell key="cell" type="check" title="Show count" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="0RF-sM-YGy">
                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                     <font key="font" metaFont="system"/>
@@ -657,7 +657,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9rs-iI-JCy">
-                                                                <rect key="frame" x="38" y="47" width="137" height="18"/>
+                                                                <rect key="frame" x="37" y="47" width="141" height="18"/>
                                                                 <buttonCell key="cell" type="radio" title="For selected folder" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="bxF-pF-kcd">
                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                     <font key="font" metaFont="system"/>
@@ -684,7 +684,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Wyb-wk-zdl">
-                                                                <rect key="frame" x="38" y="27" width="105" height="18"/>
+                                                                <rect key="frame" x="37" y="27" width="109" height="18"/>
                                                                 <buttonCell key="cell" type="radio" title="For all folders" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="JDx-zD-NwD">
                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                     <font key="font" metaFont="system"/>
@@ -711,7 +711,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="uiF-Xi-0cQ">
-                                                                <rect key="frame" x="38" y="7" width="142" height="18"/>
+                                                                <rect key="frame" x="37" y="7" width="146" height="18"/>
                                                                 <buttonCell key="cell" type="radio" title="For specific folders:" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Far-VT-IIK">
                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                     <font key="font" metaFont="system"/>
@@ -763,14 +763,14 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="KAu-cU-cJ0" secondAttribute="trailing" constant="17" id="0pa-cN-Ni2"/>
-                                                <constraint firstItem="KAu-cU-cJ0" firstAttribute="leading" secondItem="Khe-zp-uTT" secondAttribute="leading" constant="17" id="64P-lC-m0m"/>
+                                                <constraint firstItem="KAu-cU-cJ0" firstAttribute="leading" secondItem="Khe-zp-uTT" secondAttribute="leading" constant="20" id="64P-lC-m0m"/>
                                                 <constraint firstItem="1Jb-9h-IKg" firstAttribute="leading" secondItem="KAu-cU-cJ0" secondAttribute="leading" constant="18" id="Dkz-8E-v4S"/>
                                                 <constraint firstItem="uEB-WR-Zf2" firstAttribute="top" secondItem="1Jb-9h-IKg" secondAttribute="bottom" constant="8" id="Ezn-Bi-tJ8"/>
                                                 <constraint firstItem="MrS-D3-Aff" firstAttribute="leading" secondItem="1Jb-9h-IKg" secondAttribute="leading" constant="-3" id="IOt-5D-Lcy"/>
                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1Jb-9h-IKg" secondAttribute="trailing" constant="17" id="Pcl-YN-WWD"/>
                                                 <constraint firstAttribute="trailing" secondItem="MrS-D3-Aff" secondAttribute="trailing" constant="17" id="SR8-A1-dhw"/>
                                                 <constraint firstItem="1Jb-9h-IKg" firstAttribute="top" secondItem="KAu-cU-cJ0" secondAttribute="bottom" constant="8" id="fHc-4F-N7x"/>
-                                                <constraint firstItem="KAu-cU-cJ0" firstAttribute="top" secondItem="Khe-zp-uTT" secondAttribute="top" constant="3" id="iIx-gu-Wda"/>
+                                                <constraint firstItem="KAu-cU-cJ0" firstAttribute="top" secondItem="Khe-zp-uTT" secondAttribute="top" constant="16" id="iIx-gu-Wda"/>
                                                 <constraint firstAttribute="bottom" secondItem="MrS-D3-Aff" secondAttribute="bottom" constant="8" id="tAm-YQ-uQp"/>
                                             </constraints>
                                         </view>

--- a/Fastmate/Base.lproj/Main.storyboard
+++ b/Fastmate/Base.lproj/Main.storyboard
@@ -775,6 +775,65 @@
                                             </constraints>
                                         </view>
                                     </tabViewItem>
+                                    <tabViewItem label="Navigation" identifier="" id="de2-gj-Roa">
+                                        <view key="view" id="H85-Jl-7b6">
+                                            <rect key="frame" x="10" y="33" width="489" height="183"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <subviews>
+                                                <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" spacing="20" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aEB-uq-hnD">
+                                                    <rect key="frame" x="20" y="151" width="416" height="16"/>
+                                                    <subviews>
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rFl-It-twE">
+                                                            <rect key="frame" x="-2" y="0.0" width="101" height="16"/>
+                                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Up/Down arrow:" id="nFk-NF-Egv">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="grR-Um-Rz6">
+                                                            <rect key="frame" x="115" y="-1" width="117" height="18"/>
+                                                            <buttonCell key="cell" type="radio" title="Scrolls content" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="YBh-h0-Uqr">
+                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                <font key="font" metaFont="system"/>
+                                                            </buttonCell>
+                                                            <connections>
+                                                                <binding destination="aLa-hz-uMh" name="value" keyPath="values.arrowNavigatesMessageList" id="Rik-Vk-gLg">
+                                                                    <dictionary key="options">
+                                                                        <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                                                    </dictionary>
+                                                                </binding>
+                                                            </connections>
+                                                        </button>
+                                                        <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0I6-Le-pdg">
+                                                            <rect key="frame" x="250" y="-1" width="166" height="18"/>
+                                                            <buttonCell key="cell" type="radio" title="Navigates message list" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="MO5-zr-23N">
+                                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                                <font key="font" metaFont="system"/>
+                                                            </buttonCell>
+                                                            <connections>
+                                                                <binding destination="aLa-hz-uMh" name="value" keyPath="values.arrowNavigatesMessageList" id="8d3-eD-hIh"/>
+                                                            </connections>
+                                                        </button>
+                                                    </subviews>
+                                                    <visibilityPriorities>
+                                                        <integer value="1000"/>
+                                                        <integer value="1000"/>
+                                                        <integer value="1000"/>
+                                                    </visibilityPriorities>
+                                                    <customSpacing>
+                                                        <real value="3.4028234663852886e+38"/>
+                                                        <real value="3.4028234663852886e+38"/>
+                                                        <real value="3.4028234663852886e+38"/>
+                                                    </customSpacing>
+                                                </stackView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="aEB-uq-hnD" firstAttribute="top" secondItem="H85-Jl-7b6" secondAttribute="top" constant="16" id="1cP-ph-jTZ"/>
+                                                <constraint firstItem="aEB-uq-hnD" firstAttribute="leading" secondItem="H85-Jl-7b6" secondAttribute="leading" constant="20" id="50P-dr-QF8"/>
+                                            </constraints>
+                                        </view>
+                                    </tabViewItem>
                                 </tabViewItems>
                             </tabView>
                         </subviews>

--- a/Fastmate/Fastmate.js
+++ b/Fastmate/Fastmate.js
@@ -17,10 +17,39 @@ var Fastmate = {
         Fastmate.simulateKeyPress("c");
     },
 
+    deleteMessage: function() {
+        var deleteButton = document.getElementById("v34");
+        var content = document.getElementById("v54");
+        if (deleteButton != null && deleteButton.textContent == 'Delete' &&
+            document.activeElement == content) {
+            deleteButton.click();
+            return "true";
+        }
+        return "false";
+    },
+
     focusSearch: function() {
         Fastmate.simulateKeyPress("/");
     },
 
+    nextMessage: function() {
+        var content = document.getElementById("v54");
+        if (document.activeElement == content) {
+            Fastmate.simulateKeyPress("k");
+            return "true";
+        }
+        return "false";
+    },
+        
+    previousMessage: function() {
+        var content = document.getElementById("v54");
+        if (document.activeElement == content) {
+            Fastmate.simulateKeyPress("j");
+            return "true";
+        }
+        return "false";
+    },
+    
     getToolbarColor: function() {
         var toolbar = document.getElementsByClassName("v-PageHeader")[0];
         var style = window.getComputedStyle(toolbar);

--- a/Fastmate/FastmateApplication.h
+++ b/Fastmate/FastmateApplication.h
@@ -1,0 +1,9 @@
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FastmateApplication : NSApplication
+@property (weak) AppDelegate *delegate;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Fastmate/FastmateApplication.m
+++ b/Fastmate/FastmateApplication.m
@@ -1,0 +1,18 @@
+#import "AppDelegate.h"
+#import "FastmateApplication.h"
+
+@implementation FastmateApplication
+@dynamic delegate;
+
+- (void)sendEvent:(NSEvent *)event {
+    if (event.type == NSEventTypeKeyDown) {
+        if ([self.delegate handleKey:event]) {
+            // if the appDelegate handled the key, eat the event
+            return;
+        }
+    }
+
+    [super sendEvent: event];
+}
+
+@end

--- a/Fastmate/Info.plist
+++ b/Fastmate/Info.plist
@@ -48,7 +48,7 @@
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
+	<string>FastmateApplication</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict/>

--- a/Fastmate/UserDefaultsKeys.h
+++ b/Fastmate/UserDefaultsKeys.h
@@ -7,6 +7,7 @@ typedef NS_ENUM(NSUInteger, WatchedFolderType) {
     WatchedFolderTypeSpecific
 };
 
+#define ArrowNavigatesMessageListKey        @"arrowNavigatesMessageList"
 #define AutomaticUpdateChecksKey            @"automaticUpdateChecks"
 #define ShouldShowStatusBarIconKey          @"shouldShowStatusBarIcon"
 #define ShouldShowUnreadMailIndicatorKey    @"shouldShowUnreadMailIndicator"

--- a/Fastmate/WebViewController.h
+++ b/Fastmate/WebViewController.h
@@ -8,6 +8,9 @@
 
 - (void)composeNewEmail;
 - (void)focusSearchField;
+- (BOOL)deleteMessage;
+- (BOOL)nextMessage;
+- (BOOL)previousMessage;
 - (void)handleMailtoURL:(NSURL *)URL;
 - (void)handleFastmateURL:(NSURL *)URL;
 - (void)handleNotificationClickWithIdentifier:(NSString *)identifier;


### PR DESCRIPTION
- Installed a `sendEvent` hook to snoop and then optionally process and consume raw keydowns

- Installed a wrapper to make async keystrokes synchronous

- Added key handlers for several naked keystrokes, gated on appropriate document focus

If you have any questions, please ask. If you opt to reject these changes because they are too invasive (or fragile) no offense will be taken. :-)