### PR TITLE
Add https handler

### DIFF
--- a/Fastmate/AppDelegate.swift
+++ b/Fastmate/AppDelegate.swift
@@ -109,7 +109,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        if url.scheme == "fastmate" {
+        if url.scheme == "https" {
+            mainWebViewController?.handleHttpsURL(url)
+        } else if url.scheme == "fastmate" {
             mainWebViewController?.handleFastmateURL(url)
         } else if url.scheme == "mailto" {
             mainWebViewController?.handleMailtoURL(url)

--- a/Fastmate/Info.plist
+++ b/Fastmate/Info.plist
@@ -23,6 +23,16 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleURLName</key>
+			<string>Web site URL</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>https</string>
+			</array>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+		</dict>
+		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>

--- a/Fastmate/WebViewController.h
+++ b/Fastmate/WebViewController.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)deleteMessage;
 - (BOOL)nextMessage;
 - (BOOL)previousMessage;
+- (void)handleHttpsURL:(NSURL *)URL;
 - (void)handleMailtoURL:(NSURL *)URL;
 - (void)handleFastmateURL:(NSURL *)URL;
 - (void)handleNotificationClickWithIdentifier:(NSString *)identifier;

--- a/Fastmate/WebViewController.m
+++ b/Fastmate/WebViewController.m
@@ -194,6 +194,10 @@
     self.view.window.backgroundColor = color;
 }
 
+- (void)handleHttpsURL:(NSURL *)URL {
+    [self.webView loadRequest:[NSURLRequest requestWithURL:URL]];
+}
+
 - (void)handleMailtoURL:(NSURL *)URL {
     NSURLComponents *components = [[NSURLComponents alloc] initWithURL:self.baseURL resolvingAgainstBaseURL:NO];
     components.path = @"/action/compose/";


### PR DESCRIPTION
Abilitiy to open regular https URLs. I use Hammerspoon to open https://fastmail.com links directly in Fastmate.